### PR TITLE
Allow for replacing the cert infrastructure on the fly.

### DIFF
--- a/kompos8/rebar.yml
+++ b/kompos8/rebar.yml
@@ -359,6 +359,7 @@ roles:
       - cert-key-file
       - cert-cert-file
       - cert-root-file
+      - cert-ca-time
       - etcd-addresses
       - etcd-client-port
       - k8s-scope
@@ -431,6 +432,7 @@ roles:
       - cert-key-file
       - cert-cert-file
       - cert-root-file
+      - cert-ca-time
       - k8s-scope
     metadata:
       role_role_map:
@@ -519,6 +521,7 @@ roles:
       - cert-key-file
       - cert-cert-file
       - cert-root-file
+      - cert-ca-time
     type: "BarclampCluster::ServiceRole"
     icon: "store"
     events:
@@ -648,6 +651,12 @@ roles:
         map: 'cert/label'
         schema:
           type: str
+      - name: cert-ca-time
+        description: "Generation Time of the root CA"
+        default: "1970-01-01 00:00:00 -0000"
+        map: 'cert/time'
+        schema:
+          type: str
   - name: cert-ca-install-root
     jig: role-provided
     type: "BarclampCluster::InstallRootCa"
@@ -659,6 +668,7 @@ roles:
       - milestone
     wants-attribs:
       - cert-ca-label
+      - cert-ca-time
     icon: stars
     attribs:
       - name: cert-root-file
@@ -685,6 +695,7 @@ roles:
       - milestone
     wants-attribs:
       - cert-ca-label
+      - cert-ca-time
     icon: enhanced_encryption
     attribs:
       - name: cert-cert-file
@@ -781,6 +792,7 @@ roles:
       - cert-key-file
       - cert-cert-file
       - cert-root-file
+      - cert-ca-time
       - k8s-scope
     metadata:
       role_role_map:
@@ -1463,6 +1475,7 @@ roles:
       - cert-key-file
       - cert-cert-file
       - cert-root-file
+      - cert-ca-time
       - etcd-addresses
       - etcd-client-port
       - flannel-backend-type
@@ -1509,6 +1522,7 @@ roles:
       - cert-key-file
       - cert-cert-file
       - cert-root-file
+      - cert-ca-time
       - etcd-addresses
       - etcd-client-port
       - k8s-master-network


### PR DESCRIPTION
This will "rotate keys" when the cert-ca role is rerun.
Some access to the infrastructure may happen as some certs may not
match for a small window of time.  The system recovers.