### PR TITLE
Upgrade process preliminary process using version_stage to prepare clients

### DIFF
--- a/kompos8/.gitignore
+++ b/kompos8/.gitignore
@@ -14,3 +14,4 @@
 
 *.retry
 filter_plugins/ip_filters.pyc
+cluster-apj-*.yml

--- a/kompos8/group_vars/all.yml
+++ b/kompos8/group_vars/all.yml
@@ -15,6 +15,7 @@ debug: true
 
 # common paths
 bin_dir: /opt/kubernetes/server/bin
+lock_file: /opt/kubernetes/bootstrap.lock
 config_dir: /etc/kubernetes
 log_dir: /var/log/kubernetes
 

--- a/kompos8/group_vars/all.yml
+++ b/kompos8/group_vars/all.yml
@@ -73,3 +73,10 @@ source:
       kubelet: "sha256:c11ad67415a0caababfcc2fbbd9c553ec20967b4fc757ff32fda2874a0067c07"
       kube-proxy: "sha256:727f791968cd7aac381484d69e0c83b66b827c03f2fa29f5a1e7fda0d8801838"
       kubectl: "sha256:561630980ee05ab822caa160b99198cb43186ccf1bb4fda8aa6888fc96b0ee81"
+    v1.5.1:
+      kube-apiserver: "sha256:f1f36855dc0cd3f9b7706f8904feccdeccca2f90b053445b9f01ed7d8859ed70"
+      kube-controller-manager: "sha256:bde9c2949e64d059c18d8f93566a64dafc6d2e8e259a70322fb804831dfd0b5b"
+      kube-scheduler: "sha256:2d1d87d321e01af4dc02096b5dafd1190ec65e9fe26cdee7e2bf8b2e85d58cbf"
+      kubelet: "sha256:dd70f395b1a796df6adba03d6964e0e37522a9a1ee841a3f2a941dea84a5b511"
+      kube-proxy: "sha256:2fecd3c05d31f5918d5980463d91ac5253b7cdd56e863509dbe4de98fc8b0f96"
+      kubectl: "sha256:4d56b8fbec4a274a61893d244bfce532cadf313632a31a065a0edf7130066ac6"

--- a/kompos8/group_vars/all.yml
+++ b/kompos8/group_vars/all.yml
@@ -28,7 +28,7 @@ flannel_source:
 # locations of downloads
 # This section must be last in the file.
 source:
-  url: "https://storage.googleapis.com/kubernetes-release/release/{{ k8s.version }}/bin/linux/amd64"
+  url: "https://storage.googleapis.com/kubernetes-release/release/{{ kube_version|default(k8s.version) }}/bin/linux/amd64"
   checksum:
     v1.3.3:
       kube-apiserver: "sha256:a4816d0cde65368ce211464b2e85932e963caac54bcc12911b945b75d11366fc"

--- a/kompos8/rebar.yml
+++ b/kompos8/rebar.yml
@@ -187,7 +187,7 @@ roles:
           required: true
       - name: k8s-version_stage
         description: "Stage Next Kubernetes Version (Clients)"
-        default: v1.4.5
+        default: v1.4.4
         schema:
           type: str
           required: true

--- a/kompos8/rebar.yml
+++ b/kompos8/rebar.yml
@@ -185,7 +185,7 @@ roles:
         schema:
           type: str
           required: true
-      - name: k8s-version-stage
+      - name: k8s-version_stage
         description: "Stage Next Kubernetes Version (Clients)"
         default: v1.4.5
         schema:
@@ -786,7 +786,7 @@ roles:
       - cert-ca-signed-cert
     wants-attribs:
       - k8s-version
-      - k8s-version-stage
+      - k8s-version_stage
       - k8s-strict
       - k8s-log-level
       - k8s-cluster_name
@@ -847,7 +847,7 @@ roles:
       - k8s-kubelet
     wants-attribs:
       - k8s-version
-      - k8s-version-stage
+      - k8s-version_stage
       - k8s-strict
       - k8s-apiserver-port
       - k8s-master-addresses
@@ -922,7 +922,7 @@ roles:
       - k8s-prereqs
     wants-attribs:
       - k8s-version
-      - k8s-version-stage
+      - k8s-version_stage
       - k8s-strict
     metadata:
       role_role_map:

--- a/kompos8/rebar.yml
+++ b/kompos8/rebar.yml
@@ -242,7 +242,7 @@ roles:
           required: true
       - name: k8s-dashboard_version
         description: "The version of the Kubernetes Dashboard"
-        default: 'v1.4.0'
+        default: '1.5.0-beta1'
         map: 'dashboard_version'
         schema:
           type: str

--- a/kompos8/rebar.yml
+++ b/kompos8/rebar.yml
@@ -26,7 +26,6 @@ wizard:
     - k8s-master-network
     - k8s-worker-network
     - k8s-apiserver-port
-    - k8s-opencontrail_no_arp
   role_apply_order:
     - etcd
     - k8s-master
@@ -187,10 +186,9 @@ roles:
           required: true
       - name: k8s-version_stage
         description: "Stage Next Kubernetes Version (Clients)"
-        default: v1.4.4
         schema:
           type: str
-          required: true
+          required: false
       - name: k8s-strict
         description: "The Kubernetes Checksum Required"
         default: true

--- a/kompos8/rebar.yml
+++ b/kompos8/rebar.yml
@@ -181,7 +181,13 @@ roles:
           required: true
       - name: k8s-version
         description: "The Kubernetes Version"
-        default: v1.3.5
+        default: v1.4.4
+        schema:
+          type: str
+          required: true
+      - name: k8s-version-stage
+        description: "Stage Next Kubernetes Version (Clients)"
+        default: v1.4.5
         schema:
           type: str
           required: true
@@ -780,6 +786,7 @@ roles:
       - cert-ca-signed-cert
     wants-attribs:
       - k8s-version
+      - k8s-version-stage
       - k8s-strict
       - k8s-log-level
       - k8s-cluster_name
@@ -840,6 +847,7 @@ roles:
       - k8s-kubelet
     wants-attribs:
       - k8s-version
+      - k8s-version-stage
       - k8s-strict
       - k8s-apiserver-port
       - k8s-master-addresses
@@ -914,6 +922,7 @@ roles:
       - k8s-prereqs
     wants-attribs:
       - k8s-version
+      - k8s-version-stage
       - k8s-strict
     metadata:
       role_role_map:

--- a/kompos8/rebar.yml
+++ b/kompos8/rebar.yml
@@ -180,7 +180,7 @@ roles:
           required: true
       - name: k8s-version
         description: "The Kubernetes Version"
-        default: v1.4.4
+        default: v1.5.1
         schema:
           type: str
           required: true

--- a/kompos8/roles/kubectl/tasks/main.yml
+++ b/kompos8/roles/kubectl/tasks/main.yml
@@ -1,15 +1,15 @@
 --- 
 - debug: msg="Playbook source {{ playbook_source }} "
 
-- debug: msg="NOTE Staging Kubernetes Version {{k8s.version.stage}} for Upgrade from {{k8s.version}}"
-  when:  not k8s.version == "{{k8s.version.stage | default(k8s.version)}}"
+- debug: msg="NOTE Staging Kubernetes Version {{k8s.version_stage}} for Upgrade from {{k8s.version}}"
+  when:  not k8s.version == "{{k8s.version_stage | default(k8s.version)}}"
 
 # debugging variables
 - include: debug.yml
   when: debug
 # main script
 
-- include: ../shared/tasks/downloader.yml kube_component=kubectl kube_version={{k8s.version.stage | default(k8s.version)}}
+- include: ../shared/tasks/downloader.yml kube_component=kubectl kube_version={{k8s.version_stage | default(k8s.version)}}
 
 # Put the kubectl in a reasonable place to be found by script and such.
 - name: Copy kubectl to /usr/local/bin

--- a/kompos8/roles/kubectl/tasks/main.yml
+++ b/kompos8/roles/kubectl/tasks/main.yml
@@ -1,12 +1,15 @@
 --- 
 - debug: msg="Playbook source {{ playbook_source }} "
 
+- debug: msg="NOTE Staging Kubernetes Version {{k8s.version.stage}} for Upgrade from {{k8s.version}}"
+  when:  not k8s.version == "{{k8s.version.stage | default(k8s.version)}}"
+
 # debugging variables
 - include: debug.yml
   when: debug
 # main script
 
-- include: ../shared/tasks/downloader.yml kube_component=kubectl
+- include: ../shared/tasks/downloader.yml kube_component=kubectl kube_version={{k8s.version.stage | default(k8s.version)}}
 
 # Put the kubectl in a reasonable place to be found by script and such.
 - name: Copy kubectl to /usr/local/bin

--- a/kompos8/roles/kubelet/tasks/debug.yml
+++ b/kompos8/roles/kubelet/tasks/debug.yml
@@ -29,15 +29,17 @@
 - name: "DEBUG: K8s"
   debug: var=k8s
 
-- name: "VAR: Strict Checksum"
+- name: "DEBUG: Strict Checksum"
   debug: var=k8s.strict
 
-- name: "VAR: Download Source"
+- name: "DEBUG: Download Source"
   debug: var=source.url
 
-- name: "VAR: Checksum"
+- name: "DEBUG: Checksum"
   debug: var=source.checksum["{{ k8s.version }}"]
 
+- name: "DEBUG: Bootstrap Lock File"
+  debug: var=lock_file
 
 #- name: "DEBUG: Variable"
 #  debug: var=rebar

--- a/kompos8/roles/kubelet/tasks/debug.yml
+++ b/kompos8/roles/kubelet/tasks/debug.yml
@@ -17,9 +17,6 @@
 - name: "DEBUG: K8s users"
   debug: var=k8s.users
 
-- name: "DEBUG: Version"
-  debug: var=k8s.version
-
 - name: "DEBUG: K8s Master"
   debug: var=k8s.master
 

--- a/kompos8/roles/kubelet/tasks/main.yml
+++ b/kompos8/roles/kubelet/tasks/main.yml
@@ -1,11 +1,14 @@
 --- 
 - debug: msg="Playbook source {{ playbook_source }} "
 
+- debug: msg="NOTE Staging Kubernetes Version {{k8s.version.stage}} for Upgrade from {{k8s.version}}"
+  when:  not k8s.version == "{{k8s.version.stage | default(k8s.version)}}"
+
 # debugging variables
 - include: debug.yml
   when: debug
 
-- include: ../shared/tasks/downloader.yml kube_component=kubelet
+- include: ../shared/tasks/downloader.yml kube_component=kubelet kube_version={{k8s.version.stage | default(k8s.version)}}
 
 - name: Create kubelet directory
   file:

--- a/kompos8/roles/kubelet/tasks/main.yml
+++ b/kompos8/roles/kubelet/tasks/main.yml
@@ -1,14 +1,14 @@
 --- 
 - debug: msg="Playbook source {{ playbook_source }} "
 
-- debug: msg="NOTE Staging Kubernetes Version {{k8s.version.stage}} for Upgrade from {{k8s.version}}"
-  when:  not k8s.version == "{{k8s.version.stage | default(k8s.version)}}"
+- debug: msg="NOTE Staging Kubernetes Version {{k8s.version_stage}} for Upgrade from {{k8s.version}}"
+  when:  not k8s.version == "{{k8s.version_stage | default(k8s.version)}}"
 
 # debugging variables
 - include: debug.yml
   when: debug
 
-- include: ../shared/tasks/downloader.yml kube_component=kubelet kube_version={{k8s.version.stage | default(k8s.version)}}
+- include: ../shared/tasks/downloader.yml kube_component=kubelet kube_version={{k8s.version_stage | default(k8s.version)}}
 
 - name: Create kubelet directory
   file:

--- a/kompos8/roles/kubelet/templates/kubelet.service.j2
+++ b/kompos8/roles/kubelet/templates/kubelet.service.j2
@@ -22,6 +22,8 @@ ExecStart={{ bin_dir }}/kubelet \
   --serialize-image-pulls=false \
   --tls-cert-file={{k8s.kubelet.cert_file}} \
   --tls-private-key-file={{k8s.kubelet.key_file}} \
+  --bootstrap \
+  --lock-file={{ lock_file }} \
   --v=2
 Restart=on-failure
 

--- a/kompos8/roles/proxy/tasks/main.yml
+++ b/kompos8/roles/proxy/tasks/main.yml
@@ -1,11 +1,14 @@
 --- 
 - debug: msg="Playbook source {{ playbook_source }} "
 
+- debug: msg="NOTE Staging Kubernetes Version {{k8s.version.stage}} for Upgrade from {{k8s.version}}"
+  when:  not k8s.version == "{{k8s.version.stage | default(k8s.version)}}"
+
 # debugging variables
 - include: debug.yml
   when: debug
 
-- include: ../shared/tasks/downloader.yml kube_component=kube-proxy
+- include: ../shared/tasks/downloader.yml kube_component=kube-proxy kube_version={{k8s.version.stage | default(k8s.version)}}
 
 - name: install | Write kube-proxy initd script
   template: src=kube-proxy.initd.j2 dest=/etc/init.d/kube-proxy owner=root mode=0755

--- a/kompos8/roles/proxy/tasks/main.yml
+++ b/kompos8/roles/proxy/tasks/main.yml
@@ -1,14 +1,14 @@
 --- 
 - debug: msg="Playbook source {{ playbook_source }} "
 
-- debug: msg="NOTE Staging Kubernetes Version {{k8s.version.stage}} for Upgrade from {{k8s.version}}"
-  when:  not k8s.version == "{{k8s.version.stage | default(k8s.version)}}"
+- debug: msg="NOTE Staging Kubernetes Version {{k8s.version_stage}} for Upgrade from {{k8s.version}}"
+  when:  not k8s.version == "{{k8s.version_stage | default(k8s.version)}}"
 
 # debugging variables
 - include: debug.yml
   when: debug
 
-- include: ../shared/tasks/downloader.yml kube_component=kube-proxy kube_version={{k8s.version.stage | default(k8s.version)}}
+- include: ../shared/tasks/downloader.yml kube_component=kube-proxy kube_version={{k8s.version_stage | default(k8s.version)}}
 
 - name: install | Write kube-proxy initd script
   template: src=kube-proxy.initd.j2 dest=/etc/init.d/kube-proxy owner=root mode=0755

--- a/kompos8/roles/shared/tasks/downloader.yml
+++ b/kompos8/roles/shared/tasks/downloader.yml
@@ -31,7 +31,7 @@
     dest: "{{bin_dir}}/{{ kube_component }}"
     url: "{{ source.url }}/{{ kube_component }}"
     mode: 0755
-  when: not k8s.strict and source.checksum["{{ kube_version | default(k8s.version)}}"][kube_component] is not defined
+  when: not k8s.strict|default(true)
 
 - name: "Download {{ kube_component}} {{ kube_version | default(k8s.version) }} Kubernetes Executables [SLOW]"
   get_url:

--- a/kompos8/roles/shared/tasks/downloader.yml
+++ b/kompos8/roles/shared/tasks/downloader.yml
@@ -8,6 +8,12 @@
   debug: var=k8s.strict
   when: debug
 
+- name: "DEBUG: Version Staged"
+  debug: var=k8s.version.stage
+
+- name: "DEBUG: Version Passed from Caller"
+  debug: var=kube_version
+
 - name: "VAR: Download Source"
   debug: var=source.url
   when: debug
@@ -17,23 +23,23 @@
   when: debug
 
 - name: "VAR: Checksum"
-  debug: var=source.checksum["{{ k8s.version }}"]["{{ kube_component }}"]
+  debug: var=source.checksum["{{ kube_version | default(k8s.version) }}"]["{{ kube_component }}"]
   when: debug
 
-- name: "Download {{ kube_component }} {{ k8s.version }} Kubernetes Executable WITHOUT CHECKSUM [SLOW]"
+- name: "Download {{ kube_component }} {{ kube_version | default(k8s.version) }} Kubernetes Executable WITHOUT CHECKSUM [SLOW]"
   get_url:
     dest: "{{bin_dir}}/{{ kube_component }}"
     url: "{{ source.url }}/{{ kube_component }}"
     mode: 0755
-  when: not k8s.strict and source.checksum["{{k8s.version}}"][kube_component] is not defined
+  when: not k8s.strict and source.checksum["{{ kube_version | default(k8s.version)}}"][kube_component] is not defined
 
-- name: "Download {{ kube_component}} {{ k8s.version }} Kubernetes Executables [SLOW]"
+- name: "Download {{ kube_component}} {{ kube_version | default(k8s.version) }} Kubernetes Executables [SLOW]"
   get_url:
     dest: "{{bin_dir}}/{{ kube_component }}"
     checksum: "{{ item }}"
     url: "{{ source.url }}/{{ kube_component }}"
     validate_certs: yes
     mode: 0755
-  with_items: "{{ vars['source']['checksum'][k8s.version][kube_component] }}"
-  when: source.checksum["{{k8s.version}}"][kube_component] is defined and k8s.strict|default(true)
+  with_items: "{{ vars['source']['checksum'][kube_version | default(k8s.version)][kube_component] }}"
+  when: source.checksum["{{kube_version | default(k8s.version)}}"][kube_component] is defined and k8s.strict|default(true)
   ignore_errors: not k8s.strict|default(true)

--- a/kompos8/roles/shared/tasks/downloader.yml
+++ b/kompos8/roles/shared/tasks/downloader.yml
@@ -1,30 +1,38 @@
 ---
 
-- name: "DEBUG: Version"
+- name: "DOWNLOAD DEBUG VAR: Version"
   debug: var=k8s.version
   when: debug
 
-- name: "VAR: Strict Checksum"
+- name: "DOWNLOAD DEBUG VAR: Strict Checksum"
   debug: var=k8s.strict
   when: debug
 
-- name: "DEBUG: Version Staged"
+- name: "DOWNLOAD DEBUG VAR: Version Staged"
   debug: var=k8s.version_stage
 
-- name: "DEBUG: Version Passed from Caller"
+- name: "DOWNLOAD DEBUG: Version Passed from Caller"
   debug: var=kube_version
 
-- name: "VAR: Download Source"
+- name: "DOWNLOAD DEBUG VAR: Download Source"
   debug: var=source.url
   when: debug
 
-- name: "VAR: Component"
+- name: "DOWNLOAD DEBUG VAR: Component"
   debug: var=kube_component
   when: debug
 
-- name: "VAR: Checksum"
+- name: "DOWNLOAD DEBUG VAR: Checksum"
   debug: var=source.checksum["{{ kube_version | default(k8s.version) }}"]["{{ kube_component }}"]
   when: debug
+
+- name: "Ensure Version Defined (use {{ k8s.version }} if not)"
+  set_fact: kube_version="{{ k8s.version }}"
+  when: kube_version is not defined
+
+- name: "Ensure Version Set (use {{ k8s.version }} if not)"
+  set_fact: kube_version="{{ k8s.version }}"
+  when: kube_version == ""
 
 - name: "Download {{ kube_component }} {{ kube_version | default(k8s.version) }} Kubernetes Executable WITHOUT CHECKSUM [SLOW]"
   get_url:

--- a/kompos8/roles/shared/tasks/downloader.yml
+++ b/kompos8/roles/shared/tasks/downloader.yml
@@ -9,7 +9,7 @@
   when: debug
 
 - name: "DEBUG: Version Staged"
-  debug: var=k8s.version.stage
+  debug: var=k8s.version_stage
 
 - name: "DEBUG: Version Passed from Caller"
   debug: var=kube_version

--- a/kompos8/update_k8s_sums.sh
+++ b/kompos8/update_k8s_sums.sh
@@ -13,19 +13,15 @@ mkdir /tmp/$$.dl
 CODE_DIR=`pwd`
 cd /tmp/$$.dl
 
-if [[ $FILE == "" ]] ; then
-  echo "Downloading $K8S_VERSION"
-  curl https://storage.googleapis.com/kubernetes-release/release/${K8S_VERSION}/kubernetes.tar.gz -o kubernetes.tgz
-else
-  echo "Copying $FILE"
-  cp $2 kubernetes.tgz
-fi
+echo "Downloading six components for $K8S_VERSION (SLOW way, no compression)"
+curl https://storage.googleapis.com/kubernetes-release/release/${K8S_VERSION}/bin/linux/amd64/kube-apiserver -o kube-apiserver
+curl https://storage.googleapis.com/kubernetes-release/release/${K8S_VERSION}/bin/linux/amd64/kkube-controller-manager -o kube-controller-manager
+curl https://storage.googleapis.com/kubernetes-release/release/${K8S_VERSION}/bin/linux/amd64/kube-scheduler -o kube-scheduler
+curl https://storage.googleapis.com/kubernetes-release/release/${K8S_VERSION}/bin/linux/amd64/kubelet -o kubelet
+curl https://storage.googleapis.com/kubernetes-release/release/${K8S_VERSION}/bin/linux/amd64/kube-proxy -o kube-proxy
+curl https://storage.googleapis.com/kubernetes-release/release/${K8S_VERSION}/bin/linux/amd64/kubectl -o kubectl
 
-tar -xf kubernetes.tgz
-cd kubernetes/server
-tar -xf kubernetes-server-linux-amd64.tar.gz 
-cd kubernetes/server/bin
-
+echo "Compute Checksum"
 API_SERVER=$(shasum -a 256 kube-apiserver | awk '{ print $1 }')
 CONTROLLER=$(shasum -a 256 kube-controller-manager | awk '{ print $1 }')
 SCHEDULER=$(shasum -a 256 kube-scheduler | awk '{ print $1 }')
@@ -36,6 +32,7 @@ KUBECTL=$(shasum -a 256 kubectl | awk '{ print $1 }')
 cd $CODE_DIR
 rm -rf /tmp/$$.dl
 
+echo "Add checksums to group_vars/all.yml"
 echo "    ${K8S_VERSION}:" >> group_vars/all.yml
 echo "      kube-apiserver: \"sha256:$API_SERVER\"" >> group_vars/all.yml
 echo "      kube-controller-manager: \"sha256:$CONTROLLER\"" >> group_vars/all.yml


### PR DESCRIPTION
There are also some minor clean-ups.

Add concept of k8s.version_stage to allow kubelet & kubectl to be upgraded to a new version in advance of updating the control plane.  The idea is a two stage upgrade process that is managed from the K8s config role with the expectation that clients are safer to upgrade first in the process.

Default behavior is that you can ignore the version_stage property until you want to use it.  So this change should not impact default installs but enable later upgrades.

Currently: changing version or version_stage in config does NOT span role retries.  You will have to manually retry the roles that you want to change.  

Based on process in  https://docs.google.com/document/d/1vZy5YaHYcTjAs7GotuP_ENMXt1ts6JJ2orifbdlb5Js/edit# 