### PR TITLE
Not ready to go to 1.5.1 k8s - use 1.4.5 for now.

### DIFF
--- a/kompos8/rebar.yml
+++ b/kompos8/rebar.yml
@@ -180,7 +180,7 @@ roles:
           required: true
       - name: k8s-version
         description: "The Kubernetes Version"
-        default: v1.5.1
+        default: v1.4.5
         schema:
           type: str
           required: true
@@ -242,7 +242,7 @@ roles:
           required: true
       - name: k8s-dashboard_version
         description: "The version of the Kubernetes Dashboard"
-        default: '1.5.0-beta1'
+        default: 'v1.5.0'
         map: 'dashboard_version'
         schema:
           type: str

--- a/kompos8/roles/dashboard/templates/kubernetes-dashboard.yml.j2
+++ b/kompos8/roles/dashboard/templates/kubernetes-dashboard.yml.j2
@@ -21,7 +21,6 @@ apiVersion: extensions/v1beta1
 metadata:
   labels:
     app: kubernetes-dashboard
-    version: {{ dashboard_version }}
   name: kubernetes-dashboard
   namespace: kube-system
 spec:

--- a/kompos8/roles/kubelet/templates/kubelet.service.j2
+++ b/kompos8/roles/kubelet/templates/kubelet.service.j2
@@ -22,8 +22,6 @@ ExecStart={{ bin_dir }}/kubelet \
   --serialize-image-pulls=false \
   --tls-cert-file={{k8s.kubelet.cert_file}} \
   --tls-private-key-file={{k8s.kubelet.key_file}} \
-  --bootstrap \
-  --lock-file={{ lock_file }} \
   --v=2
 Restart=on-failure
 


### PR DESCRIPTION
Dashboard at 1.5.0 works.
Fix some flags issues.